### PR TITLE
Support filtering on associated tables in QueryFilter

### DIFF
--- a/apps/ex_scim_ecto/lib/ex_scim_ecto/query_filter.ex
+++ b/apps/ex_scim_ecto/lib/ex_scim_ecto/query_filter.ex
@@ -17,57 +17,136 @@ defmodule ExScimEcto.QueryFilter do
   def apply_filter(query, nil, _opts), do: query
 
   def apply_filter(query, ast, opts) do
+    required_assocs = collect_associations(ast, opts)
+    query = ensure_joins(query, required_assocs)
     dynamic = build_dynamic(ast, opts)
-    from(q in query, where: ^dynamic)
+    query = from(q in query, where: ^dynamic)
+
+    if MapSet.size(required_assocs) > 0 do
+      from(q in query, distinct: true)
+    else
+      query
+    end
   end
 
-  defp build_dynamic({:eq, field, value}, opts) do
-    dynamic([u], field(u, ^resolve_field(field, opts)) == ^value)
+  # Comparison operators
+  for op <- [:eq, :ne, :gt, :ge, :lt, :le] do
+    defp build_dynamic({unquote(op), field, value}, opts) do
+      apply_comparison(resolve_field(field, opts), unquote(op), value)
+    end
   end
 
-  defp build_dynamic({:ne, field, value}, opts) do
-    dynamic([u], field(u, ^resolve_field(field, opts)) != ^value)
+  # Like operators
+  for op <- [:co, :sw, :ew] do
+    defp build_dynamic({unquote(op), field, value}, opts) do
+      apply_like(resolve_field(field, opts), unquote(op), value)
+    end
   end
 
-  defp build_dynamic({:co, field, value}, opts) do
-    dynamic([u], like(field(u, ^resolve_field(field, opts)), ^"%#{value}%"))
-  end
-
-  defp build_dynamic({:sw, field, value}, opts) do
-    dynamic([u], like(field(u, ^resolve_field(field, opts)), ^"#{value}%"))
-  end
-
-  defp build_dynamic({:ew, field, value}, opts) do
-    dynamic([u], like(field(u, ^resolve_field(field, opts)), ^"%#{value}"))
-  end
-
+  # Present operator
   defp build_dynamic({:pr, field}, opts) do
-    dynamic([u], not is_nil(field(u, ^resolve_field(field, opts))))
+    apply_present(resolve_field(field, opts))
   end
 
-  defp build_dynamic({:gt, field, value}, opts) do
-    dynamic([u], field(u, ^resolve_field(field, opts)) > ^value)
-  end
-
-  defp build_dynamic({:ge, field, value}, opts) do
-    dynamic([u], field(u, ^resolve_field(field, opts)) >= ^value)
-  end
-
-  defp build_dynamic({:lt, field, value}, opts) do
-    dynamic([u], field(u, ^resolve_field(field, opts)) < ^value)
-  end
-
-  defp build_dynamic({:le, field, value}, opts) do
-    dynamic([u], field(u, ^resolve_field(field, opts)) <= ^value)
-  end
-
+  # Logical operators
   defp build_dynamic({:and, left, right}, opts) do
-    dynamic([u], ^build_dynamic(left, opts) and ^build_dynamic(right, opts))
+    dynamic([], ^build_dynamic(left, opts) and ^build_dynamic(right, opts))
   end
 
   defp build_dynamic({:or, left, right}, opts) do
-    dynamic([u], ^build_dynamic(left, opts) or ^build_dynamic(right, opts))
+    dynamic([], ^build_dynamic(left, opts) or ^build_dynamic(right, opts))
   end
+
+  defp build_dynamic({:not, expr}, opts) do
+    dynamic([], not (^build_dynamic(expr, opts)))
+  end
+
+  # Comparison helpers — atom (root table column)
+  defp apply_comparison(field, :eq, value) when is_atom(field) do
+    dynamic([u], field(u, ^field) == ^value)
+  end
+
+  defp apply_comparison(field, :ne, value) when is_atom(field) do
+    dynamic([u], field(u, ^field) != ^value)
+  end
+
+  defp apply_comparison(field, :gt, value) when is_atom(field) do
+    dynamic([u], field(u, ^field) > ^value)
+  end
+
+  defp apply_comparison(field, :ge, value) when is_atom(field) do
+    dynamic([u], field(u, ^field) >= ^value)
+  end
+
+  defp apply_comparison(field, :lt, value) when is_atom(field) do
+    dynamic([u], field(u, ^field) < ^value)
+  end
+
+  defp apply_comparison(field, :le, value) when is_atom(field) do
+    dynamic([u], field(u, ^field) <= ^value)
+  end
+
+  # Comparison helpers — association
+  defp apply_comparison({:assoc, assoc_name, col}, :eq, value) do
+    dynamic([{^assoc_name, x}], field(x, ^col) == ^value)
+  end
+
+  defp apply_comparison({:assoc, assoc_name, col}, :ne, value) do
+    dynamic([{^assoc_name, x}], field(x, ^col) != ^value)
+  end
+
+  defp apply_comparison({:assoc, assoc_name, col}, :gt, value) do
+    dynamic([{^assoc_name, x}], field(x, ^col) > ^value)
+  end
+
+  defp apply_comparison({:assoc, assoc_name, col}, :ge, value) do
+    dynamic([{^assoc_name, x}], field(x, ^col) >= ^value)
+  end
+
+  defp apply_comparison({:assoc, assoc_name, col}, :lt, value) do
+    dynamic([{^assoc_name, x}], field(x, ^col) < ^value)
+  end
+
+  defp apply_comparison({:assoc, assoc_name, col}, :le, value) do
+    dynamic([{^assoc_name, x}], field(x, ^col) <= ^value)
+  end
+
+  # Like helpers — atom (root table column)
+  defp apply_like(field, :co, value) when is_atom(field) do
+    dynamic([u], like(field(u, ^field), ^"%#{value}%"))
+  end
+
+  defp apply_like(field, :sw, value) when is_atom(field) do
+    dynamic([u], like(field(u, ^field), ^"#{value}%"))
+  end
+
+  defp apply_like(field, :ew, value) when is_atom(field) do
+    dynamic([u], like(field(u, ^field), ^"%#{value}"))
+  end
+
+  # Like helpers — association
+  defp apply_like({:assoc, assoc_name, col}, :co, value) do
+    dynamic([{^assoc_name, x}], like(field(x, ^col), ^"%#{value}%"))
+  end
+
+  defp apply_like({:assoc, assoc_name, col}, :sw, value) do
+    dynamic([{^assoc_name, x}], like(field(x, ^col), ^"#{value}%"))
+  end
+
+  defp apply_like({:assoc, assoc_name, col}, :ew, value) do
+    dynamic([{^assoc_name, x}], like(field(x, ^col), ^"%#{value}"))
+  end
+
+  # Present helpers
+  defp apply_present(field) when is_atom(field) do
+    dynamic([u], not is_nil(field(u, ^field)))
+  end
+
+  defp apply_present({:assoc, assoc_name, col}) do
+    dynamic([{^assoc_name, x}], not is_nil(field(x, ^col)))
+  end
+
+  # Field resolution
 
   defp resolve_field(scim_path, opts) do
     filter_mapping = Keyword.get(opts, :filter_mapping, %{})
@@ -99,6 +178,57 @@ defmodule ExScimEcto.QueryFilter do
 
       mapped_atom when is_atom(mapped_atom) ->
         mapped_atom
+
+      {:assoc, assoc_name, field_name} = assoc_ref
+      when is_atom(assoc_name) and is_atom(field_name) ->
+        assoc_ref
     end
+  end
+
+  # Association collection — walks the AST and collects unique association names
+
+  defp collect_associations(ast, opts) do
+    do_collect_associations(ast, opts, MapSet.new())
+  end
+
+  defp do_collect_associations(nil, _opts, acc), do: acc
+
+  defp do_collect_associations({op, field, _value}, opts, acc)
+       when op in [:eq, :ne, :co, :sw, :ew, :gt, :ge, :lt, :le] do
+    case resolve_field(field, opts) do
+      {:assoc, assoc_name, _col} -> MapSet.put(acc, assoc_name)
+      _atom -> acc
+    end
+  end
+
+  defp do_collect_associations({:pr, field}, opts, acc) do
+    case resolve_field(field, opts) do
+      {:assoc, assoc_name, _col} -> MapSet.put(acc, assoc_name)
+      _atom -> acc
+    end
+  end
+
+  defp do_collect_associations({op, left, right}, opts, acc) when op in [:and, :or] do
+    acc = do_collect_associations(left, opts, acc)
+    do_collect_associations(right, opts, acc)
+  end
+
+  defp do_collect_associations({:not, expr}, opts, acc) do
+    do_collect_associations(expr, opts, acc)
+  end
+
+  # Join management
+
+  defp ensure_joins(query, assoc_names) do
+    Enum.reduce(assoc_names, query, fn assoc_name, q ->
+      if has_named_binding?(q, assoc_name) do
+        q
+      else
+        from(root in q,
+          left_join: assoc in assoc(root, ^assoc_name),
+          as: ^assoc_name
+        )
+      end
+    end)
   end
 end

--- a/apps/ex_scim_ecto/test/ex_scim_ecto/query_filter_test.exs
+++ b/apps/ex_scim_ecto/test/ex_scim_ecto/query_filter_test.exs
@@ -1,0 +1,240 @@
+defmodule ExScimEcto.QueryFilterTest do
+  use ExUnit.Case, async: true
+
+  alias ExScimEcto.QueryFilter
+  import Ecto.Query
+
+  # Minimal test schemas — no database needed, we only inspect the Ecto.Query struct.
+
+  defmodule UserEmail do
+    use Ecto.Schema
+
+    schema "user_emails" do
+      field :default_value, :string
+      field :type, :string
+      belongs_to :user, ExScimEcto.QueryFilterTest.User
+    end
+  end
+
+  defmodule User do
+    use Ecto.Schema
+
+    schema "users" do
+      field :user_name, :string
+      field :given_name, :string
+      field :family_name, :string
+      field :active, :boolean
+      has_many :user_emails, ExScimEcto.QueryFilterTest.UserEmail
+    end
+  end
+
+  @assoc_opts [
+    filter_mapping: %{
+      "emails.value" => {:assoc, :user_emails, :default_value},
+      "emails.type" => {:assoc, :user_emails, :type},
+      "name.givenName" => :given_name
+    }
+  ]
+
+  @atom_opts [
+    filter_mapping: %{
+      "name.givenName" => :given_name,
+      "name.familyName" => :family_name
+    }
+  ]
+
+  defp base_query, do: from(u in User)
+
+  # Helper to extract join info from an Ecto.Query
+  defp join_count(query), do: length(query.joins)
+
+  defp has_join_on?(query, assoc_name) do
+    Enum.any?(query.joins, fn %{as: as} -> as == assoc_name end)
+  end
+
+  defp has_distinct?(query), do: query.distinct != nil
+
+  # 1. Simple atom mapping still works (no joins added)
+
+  describe "atom field mapping" do
+    test "eq with atom mapping produces no joins" do
+      ast = {:eq, "name.givenName", "John"}
+      query = QueryFilter.apply_filter(base_query(), ast, @atom_opts)
+
+      assert join_count(query) == 0
+      refute has_distinct?(query)
+    end
+
+    test "2-arity apply_filter still works" do
+      # Ensure atom_to_existing_atom path works
+      ast = {:eq, "user_name", "john"}
+      query = QueryFilter.apply_filter(base_query(), ast)
+
+      assert join_count(query) == 0
+    end
+  end
+
+  # 2. Association mapping adds named LEFT JOIN and filters on association field
+
+  describe "association field mapping" do
+    test "eq on association adds a named left join" do
+      ast = {:eq, "emails.value", "john@example.com"}
+      query = QueryFilter.apply_filter(base_query(), ast, @assoc_opts)
+
+      assert join_count(query) == 1
+      assert has_join_on?(query, :user_emails)
+    end
+
+    test "join is a left join" do
+      ast = {:eq, "emails.value", "john@example.com"}
+      query = QueryFilter.apply_filter(base_query(), ast, @assoc_opts)
+
+      [join] = query.joins
+      assert join.qual == :left
+    end
+  end
+
+  # 3. distinct: true added only when associations are joined
+
+  describe "distinct behavior" do
+    test "distinct added when association join present" do
+      ast = {:eq, "emails.value", "john@example.com"}
+      query = QueryFilter.apply_filter(base_query(), ast, @assoc_opts)
+
+      assert has_distinct?(query)
+    end
+
+    test "distinct not added for atom-only filters" do
+      ast = {:eq, "name.givenName", "John"}
+      query = QueryFilter.apply_filter(base_query(), ast, @atom_opts)
+
+      refute has_distinct?(query)
+    end
+  end
+
+  # 4. Two filters on same association produce only one join
+
+  describe "join deduplication" do
+    test "and with two filters on same association produces one join" do
+      ast = {:and,
+        {:eq, "emails.value", "john@example.com"},
+        {:eq, "emails.type", "work"}
+      }
+      query = QueryFilter.apply_filter(base_query(), ast, @assoc_opts)
+
+      assert join_count(query) == 1
+      assert has_join_on?(query, :user_emails)
+    end
+  end
+
+  # 5. Mixed local + association filters
+
+  describe "mixed local and association filters" do
+    test "and with local and association filter" do
+      ast = {:and,
+        {:eq, "name.givenName", "John"},
+        {:eq, "emails.value", "john@example.com"}
+      }
+      query = QueryFilter.apply_filter(base_query(), ast, @assoc_opts)
+
+      assert join_count(query) == 1
+      assert has_join_on?(query, :user_emails)
+      assert has_distinct?(query)
+    end
+
+    test "or with local and association filter" do
+      ast = {:or,
+        {:eq, "name.givenName", "John"},
+        {:eq, "emails.value", "john@example.com"}
+      }
+      query = QueryFilter.apply_filter(base_query(), ast, @assoc_opts)
+
+      assert join_count(query) == 1
+      assert has_distinct?(query)
+    end
+  end
+
+  # 6. All 10 operators work with association refs
+
+  describe "all operators with association refs" do
+    for op <- [:eq, :ne, :gt, :ge, :lt, :le] do
+      test "#{op} works with association field" do
+        ast = {unquote(op), "emails.value", "test"}
+        query = QueryFilter.apply_filter(base_query(), ast, @assoc_opts)
+
+        assert join_count(query) == 1
+        assert has_join_on?(query, :user_emails)
+      end
+    end
+
+    for op <- [:co, :sw, :ew] do
+      test "#{op} works with association field" do
+        ast = {unquote(op), "emails.value", "test"}
+        query = QueryFilter.apply_filter(base_query(), ast, @assoc_opts)
+
+        assert join_count(query) == 1
+        assert has_join_on?(query, :user_emails)
+      end
+    end
+
+    test "pr works with association field" do
+      ast = {:pr, "emails.value"}
+      query = QueryFilter.apply_filter(base_query(), ast, @assoc_opts)
+
+      assert join_count(query) == 1
+      assert has_join_on?(query, :user_emails)
+    end
+  end
+
+  # 7. nil AST returns query unchanged
+
+  describe "nil AST" do
+    test "apply_filter/2 with nil returns query unchanged" do
+      query = base_query()
+      assert QueryFilter.apply_filter(query, nil) == query
+    end
+
+    test "apply_filter/3 with nil returns query unchanged" do
+      query = base_query()
+      assert QueryFilter.apply_filter(query, nil, @assoc_opts) == query
+    end
+  end
+
+  # 8. Pre-existing named binding is not duplicated
+
+  describe "pre-existing binding" do
+    test "does not duplicate join when binding already exists" do
+      pre_joined =
+        from(u in User,
+          left_join: ue in assoc(u, :user_emails),
+          as: :user_emails
+        )
+
+      ast = {:eq, "emails.value", "john@example.com"}
+      query = QueryFilter.apply_filter(pre_joined, ast, @assoc_opts)
+
+      assert join_count(query) == 1
+    end
+  end
+
+  # 9. :not wrapping an association filter
+
+  describe "not operator" do
+    test "not wrapping association filter works" do
+      ast = {:not, {:eq, "emails.value", "john@example.com"}}
+      query = QueryFilter.apply_filter(base_query(), ast, @assoc_opts)
+
+      assert join_count(query) == 1
+      assert has_join_on?(query, :user_emails)
+      assert has_distinct?(query)
+    end
+
+    test "not wrapping local filter works" do
+      ast = {:not, {:eq, "name.givenName", "John"}}
+      query = QueryFilter.apply_filter(base_query(), ast, @atom_opts)
+
+      assert join_count(query) == 0
+      refute has_distinct?(query)
+    end
+  end
+end


### PR DESCRIPTION
Add {:assoc, name, column} tuple format to filter_mapping so SCIM attribute paths can resolve to joined tables instead of only root columns. Joins are left joins, deduplicated by named binding, and distinct is added automatically when associations are involved.